### PR TITLE
Update ft_printf.c

### DIFF
--- a/Rank02/ft_printf/ft_printf.c
+++ b/Rank02/ft_printf/ft_printf.c
@@ -26,7 +26,7 @@ int	ft_printf_base(long nbr, int *count, int base)
 	{
 		ft_printf_char('-', count);
 		nbr *= -1;
-		ft_printf_base(nbr, count, base);
+		//ft_printf_base(nbr, count, base);
 	}
 	if (nbr > base)
 	{


### PR DESCRIPTION
Hello JC !

Il y a un bug dans ta gestion des négatifs, au niveau du ft_printf_base.

Si je passe 42 à -42, il l'imprime 2 fois.
ft_printf() => Magic number is -4242
printf() => Magic number is -42

C'est parce que tu rappelles la fonction après l'avoir passé en négatif, alors que le nbr est désormais positif (avec le nbr *= -1) et peut continuer son chemin de condition : 
"if (nbr < 0)
	{
		ft_printf_char('-', count);
		nbr *= -1;
		-------------> ft_printf_base(nbr, count, base);
	}"
Voilà ;D 
Merci en tout cas, c est top dans les revisions, c est un super ft_printf !